### PR TITLE
Add a new rule for my.initialize validation

### DIFF
--- a/docs/rules/ensure-super-call-in-initialize.md
+++ b/docs/rules/ensure-super-call-in-initialize.md
@@ -1,0 +1,32 @@
+# Ensure that my.initialize overrides perform a super call
+
+Check that all implementations of `my.initialize` perform a super call with the correct argument.
+
+## Rule Details
+
+This rule aims to ensure that all overrides of `my.initialize` will perform a valid super call to correctly initialize new instances.
+
+The following patterns are considered warnings:
+
+```js
+
+my.initialize = function(spec) {
+    my.super();
+}
+
+my.initialize = function(spec) {
+    my.a = spec.a;
+}
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+my.initialize = function(spec) {
+    my.super(spec);
+    my.a = spec.a;
+}
+
+```

--- a/lib/rules/ensure-super-calls-in-initialize.js
+++ b/lib/rules/ensure-super-calls-in-initialize.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview All implementations of my.initialize should perform a super call.
+ * @author Nicolas Petton & Benjamin Van Ryseghem
+ * @copyright 2016 Nicolas Petton & Benjamin Van Ryseghem. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function isInitializeMethod(node) {
+	var expression = node.expression;
+	return expression.type === 'AssignmentExpression' &&
+		expression.left.type === 'MemberExpression' &&
+		expression.left.object.name === 'my' &&
+		expression.left.property.name === 'initialize';
+}
+
+function isSuperCall(node) {
+	var callee = node.callee;
+	return callee.type === 'MemberExpression' &&
+		callee.object.name === 'my' &&
+		callee.property.name === 'super';
+}
+
+module.exports = function(context) {
+	var requireSuperCall = false;
+	var superCallNode = null;
+
+	return {
+		'ExpressionStatement': function(node) {
+			if (isInitializeMethod(node)) {
+				requireSuperCall = true;
+			}
+		},
+		'CallExpression': function(node) {
+			if (!requireSuperCall) {
+				return;
+			}
+
+			if (isSuperCall(node)) {
+				superCallNode = node;
+			}
+		},
+		'ExpressionStatement:exit': function(node) {
+			if (isInitializeMethod(node)) {
+				var argParams = node.expression.right.params;
+				if (argParams.length === 0) {
+					context.report(node, '`spec` argument missing.');
+				} else {
+					var specArgName = node.expression.right.params.length && node.expression.right.params[0].name;
+					if (requireSuperCall && !superCallNode) {
+						context.report(node, 'super call not performed in `my.initialize`.');
+					} else if (superCallNode.arguments.length !== 1 || superCallNode.arguments[0].name !== specArgName) {
+						context.report(superCallNode, 'spec argument missing from super call.');
+					}
+				}
+				requireSuperCall = false;
+				superCallNode = null;
+			}
+		}
+	};
+};
+
+module.exports.schema = [
+	// fill in your schema
+];

--- a/tests/lib/rules/ensure-super-calls-in-initialize.js
+++ b/tests/lib/rules/ensure-super-calls-in-initialize.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview All implementations of my.initialize should perform a super call.
+ * @author Nicolas Petton & Benjamin Van Ryseghem
+ * @copyright 2016 Nicolas Petton & Benjamin Van Ryseghem. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/ensure-super-calls-in-initialize"),
+
+	RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("ensure-super-calls-in-initialize", rule, {
+
+	valid: [
+		{
+			code: "my.initialize = function(spec) {my.super(spec);}"
+		},
+		{
+			code: "my.initialize = function(spec) {var a = 1; my.super(spec); return a;}"
+		}
+	],
+
+	invalid: [
+		{
+			code: "my.initialize = function(spec) {}",
+			errors: [
+				{
+					message: "super call not performed in `my.initialize`.",
+					type: "ExpressionStatement"
+				}
+			]
+		},
+		{
+			code: "my.initialize = function(spec) {var a = 1; return a;}",
+			errors: [
+				{
+					message: "super call not performed in `my.initialize`.",
+					type: "ExpressionStatement"
+				}
+			]
+		},
+		{
+			code: "my.initialize = function(spec) {my.super();}",
+			errors: [
+				{
+					message: "spec argument missing from super call.",
+					type: "CallExpression"
+				}
+			]
+		}
+	]
+});


### PR DESCRIPTION
When overriding `my.initialize`, make sure that a super call is
performed.

* docs/rules/ensure-super-call-in-initialize.md:
* lib/rules/ensure-super-calls-in-initialize.js:
* tests/lib/rules/ensure-super-calls-in-initialize.js: New files.