### PR TITLE
Decompose no-untranslated-polyglots into 2 rules

### DIFF
--- a/lib/rules/no-untranslated-polyglots.js
+++ b/lib/rules/no-untranslated-polyglots.js
@@ -21,47 +21,18 @@ module.exports = function(context) {
 	}
 
 	function checkPolyglotArgument(argument, node) {
-		if (!argument) {
-			context.report(node, 'Polyglot should have at least one argument');
+		var text = argument.value;
+		if (text === undefined) {
+			return;
 		}
-
-		switch (argument.type) {
-			case 'Identifier':
-				context.report(node, 'No variable should be passed. Inline `{{text}}`', {text: argument.name});
-				break;
-			case 'BinaryExpression':
-				if (argument.operator === '+') {
-					context.report(node, 'Replace concatenation of polyglots with template.');
-				} else if (argument.operator === '||') {
-					context.report(node, 'Replace concatenation of polyglots with template.');
-				} else {
-					context.report(node, 'It looks, like there is something fishy with `{{text}}`', {text: argument.value});
-				}
-				break;
-			case 'MemberExpression':
-				context.report(node, 'Translating a member looks like a bad idea. Maybe a switch case could do it?');
-				break;
-			case 'CallExpression':
-				context.report(node, 'Result of invokation should not be translated. The invoked function could return the translation directly maybe?');
-				break;
-			case 'Literal':
-				var text = argument.value;
-				if (text === undefined) {
-					return;
-				}
-				var translation = translations[text];
-				if (translation === undefined) {
-					context.report(node, '\'{{text}}\' is not translatable.', {text: text});
-				} else if (!translation.hasOwnProperty(language)) {
-					context.report(node, '\'{{text}}\' is not translated into {{language}}.', {
-						text: text,
-						language: language
-					});
-				}
-				break;
-			default:
-				context.report(node, 'Unknown Type: ' + argument.type);
-				break;
+		var translation = translations[text];
+		if (translation === undefined) {
+			context.report(node, '\'{{text}}\' is not translatable.', {text: text});
+		} else if (!translation.hasOwnProperty(language)) {
+			context.report(node, '\'{{text}}\' is not translated into {{language}}.', {
+				text: text,
+				language: language
+			});
 		}
 	}
 
@@ -70,7 +41,7 @@ module.exports = function(context) {
 	return {
 		'CallExpression': function(node) {
 			// Polyglot calls
-			if (node.callee.name === '_') {
+			if (node.callee.name === '_' && node.arguments[0] && node.arguments[0].type == 'Literal') {
 
 				// Where text is not translated
 				checkPolyglotArgument(node.arguments[0], node);

--- a/lib/rules/only-literal-polyglots.js
+++ b/lib/rules/only-literal-polyglots.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Only literals should be polyglots
+ * @author Benjamin Van Ryseghem
+ * @copyright 2016 Benjamin Van Ryseghem. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+	function checkPolyglotArgument(argument, node) {
+		if (!argument) {
+			context.report(node, 'Polyglot should have at least one argument');
+			return;
+		}
+
+		switch (argument.type) {
+			case 'Identifier':
+				context.report(node, 'No variable should be passed. Inline `{{text}}`', {text: argument.name});
+				break;
+			case 'BinaryExpression':case 'LogicalExpression':
+				if (argument.operator === '+') {
+					context.report(node, 'Replace concatenation of polyglots with template');
+				} else if (argument.operator === '||') {
+					context.report(node, 'Replace concatenation of polyglots with template');
+				} else {
+					context.report(node, 'It looks like there is something fishy with the polyglot');
+				}
+				break;
+			case 'MemberExpression':
+				context.report(node, 'Translating a member looks like a bad idea. Maybe a switch case could do it?');
+				break;
+			case 'CallExpression':
+				context.report(node, 'Result of invokation should not be translated. The invoked function could return the translation directly maybe?');
+				break;
+			case 'Literal':
+				// A 'Literal' is the only acceptable argument type
+				break;
+			default:
+				context.report(node, 'Unknown Type: ' + argument.type);
+				break;
+		}
+	}
+
+	return {
+		'CallExpression': function(node) {
+			// Polyglot calls
+			if (node.callee.name === '_') {
+				checkPolyglotArgument(node.arguments[0], node);
+			}
+		}
+	};
+};
+
+module.exports.schema = [
+	{
+		"type": "object",
+		"additionalProperties": false
+	}
+];

--- a/tests/lib/rules/only-literal-polyglots.js
+++ b/tests/lib/rules/only-literal-polyglots.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Only literals should be polyglots
+ * @author Damien Cassou
+ * @copyright 2016 Damien Cassou. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/only-literal-polyglots"),
+
+	RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("only-literal-polyglots", rule, {
+
+	valid: [
+		{
+			code: "_('A literal is ok');"
+		}
+	],
+
+	invalid: [
+		{
+			code: "_()",
+			errors: [
+				{
+					message: "Polyglot should have at least one argument",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_(myvar)",
+			errors: [
+				{
+					message: "No variable should be passed. Inline `myvar`",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_('foo' + 'bar')",
+			errors: [
+				{
+					message: "Replace concatenation of polyglots with template",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_('foo' || 'bar')",
+			errors: [
+				{
+					message: "Replace concatenation of polyglots with template",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_('foo' - 'bar')",
+			errors: [
+				{
+					message: "It looks like there is something fishy with the polyglot",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_(my.bar)",
+			errors: [
+				{
+					message: "Translating a member looks like a bad idea. Maybe a switch case could do it?",
+					type: "CallExpression"
+				}
+			]
+		},
+		{
+			code: "_('foo' ? 'bar' : 'baz')",
+			errors: [
+				{
+					message: "Unknown Type: ConditionalExpression",
+					type: "CallExpression"
+				}
+			]
+		}
+	]
+});


### PR DESCRIPTION
Rule no-untranslated-polyglots contains code not related to
"translation". I extracted only-literal-polyglots out of it so
responsibilities are clearer. I also added unit tests.